### PR TITLE
 Implement lowering for scf.for

### DIFF
--- a/include/Wasm/ConversionPatterns/ScfToWasmPatterns.h
+++ b/include/Wasm/ConversionPatterns/ScfToWasmPatterns.h
@@ -1,0 +1,14 @@
+#ifndef WASM_SCFTOWASMPATTERNS_H
+#define WASM_SCFTOWASMPATTERNS_H
+
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir::wasm {
+void populateScfToWasmPatterns(TypeConverter &typeConverter,
+                               RewritePatternSet &patterns);
+
+} // namespace mlir::wasm
+
+#endif // WASM_SCFTOWASMPATTERNS_H

--- a/include/Wasm/WasmOps.td
+++ b/include/Wasm/WasmOps.td
@@ -84,6 +84,8 @@ def Wasm_IShrUOp : Wasm_IntegerBinaryOp<"shr_u">;
 def Wasm_IRotlOp : Wasm_IntegerBinaryOp<"rotl">;
 def Wasm_IRotrOp : Wasm_IntegerBinaryOp<"rotr">;
 
+def Wasm_ILtUOp : Wasm_IntegerBinaryOp<"lt_u">;
+
 // floating-point unary operations
 
 def Wasm_FAbsOp : Wasm_FloatUnaryOp<"abs">;
@@ -383,5 +385,33 @@ def Wasm_Unreachable : Wasm_Op<"unreachable", []> {
 }
 
 // TODO: control flow instructions
+
+def Wasm_LoopOp: Wasm_Op<"loop"> {
+    // TODO: Handle loop-carried values
+    let regions = (region AnyRegion:$body);
+
+    let builders = [
+        OpBuilder<(ins)>,
+    ];
+}
+
+def Wasm_LoopEndOp: Wasm_Op<"loop_end", [Terminator]> {
+    // TODO: HasParent<LoopOp>
+}
+
+def Wasm_BranchOp: Wasm_Op<"br", [Terminator]> {
+    let successors = (successor AnySuccessor:$dest);
+}
+
+def Wasm_CondBranchOp: Wasm_Op<"cond_br", [Terminator]> {
+    let successors = (successor AnySuccessor:$dest);
+}
+
+def Wasm_NoOp : Wasm_Op<"noop", []> {
+    let summary = "No operation";
+    let description = [{
+        The `noop` operation does nothing.
+    }];
+}
 
 #endif // WASM_OPS

--- a/include/Wasm/WasmPasses.td
+++ b/include/Wasm/WasmPasses.td
@@ -20,7 +20,8 @@ def ConvertToWasm : Pass<"convert-to-wasm", "ModuleOp"> {
     "wasm::WasmDialect",
     "arith::ArithDialect",
     "func::FuncDialect",
-  // TODO: Add scf and memref dialects
+    "scf::SCFDialect",
+  // TODO: Add memref dialects
   ];
 }
 

--- a/lib/Wasm/ConversionPatterns/ScfToWasmPatterns.cpp
+++ b/lib/Wasm/ConversionPatterns/ScfToWasmPatterns.cpp
@@ -1,0 +1,97 @@
+#include "Wasm/ConversionPatterns/ScfToWasmPatterns.h"
+#include "Wasm/WasmOps.h"
+
+namespace mlir::wasm {
+
+struct ForLowering : public OpConversionPattern<scf::ForOp> {
+  using OpConversionPattern<scf::ForOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(scf::ForOp forOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = forOp.getLoc();
+
+    auto *firstBlock = &forOp.getRegion().front();
+    auto *lastBlock = &forOp.getRegion().back();
+
+    auto loopOp = rewriter.create<wasm::LoopOp>(loc);
+    rewriter.inlineRegionBefore(forOp.getRegion(), loopOp.getBody(),
+                                loopOp.getBody().end());
+
+    // firstBlockHead is the entrypoint of the loop. This does not have any
+    // predecessors
+    auto *firstBlockHead = firstBlock;
+    // looping logic is defined in the condBlock
+    auto *condBlock = rewriter.splitBlock(firstBlock, firstBlock->begin());
+    auto *firstBlockEnd = rewriter.splitBlock(condBlock, condBlock->begin());
+    // induction variable is updated in the bodyEndBlock
+    Block *bodyEndBlock;
+    if (firstBlock == lastBlock) {
+      bodyEndBlock = firstBlockEnd;
+    } else {
+      bodyEndBlock = lastBlock;
+    }
+    Operation *terminator = bodyEndBlock->getTerminator();
+
+    rewriter.setInsertionPointToEnd(bodyEndBlock);
+    auto *terminationBlock = rewriter.createBlock(&loopOp.getRegion());
+
+    // TODO: we don't really need this
+    // we added this to avoid the error that the entry block should have no
+    // predecessors
+    rewriter.setInsertionPointToEnd(firstBlockHead);
+    rewriter.create<wasm::BranchOp>(loc, condBlock);
+
+    // set branching logic here
+    // TODO: handle for loops with loop-carried values
+    auto inductionVariable = firstBlockHead->getArgument(0);
+
+    rewriter.setInsertionPointToEnd(condBlock);
+    Value lowerBound = forOp.getLowerBound();
+    Value upperBound = forOp.getUpperBound();
+
+    if (!lowerBound || !upperBound) {
+      return rewriter.notifyMatchFailure(forOp, "missing loop bounds");
+    }
+
+    auto castedInductionVariable = typeConverter->materializeTargetConversion(
+        rewriter, loc, typeConverter->convertType(inductionVariable.getType()),
+        inductionVariable);
+    auto castedUpperBound = typeConverter->materializeTargetConversion(
+        rewriter, loc, typeConverter->convertType(upperBound.getType()),
+        upperBound);
+    rewriter.create<wasm::TempLocalGetOp>(loc, castedInductionVariable);
+    rewriter.create<wasm::TempLocalGetOp>(loc, castedUpperBound);
+
+    rewriter.create<wasm::ILtUOp>(loc, rewriter.getI32Type()); // FIXME
+    rewriter.create<wasm::CondBranchOp>(loc, terminationBlock);
+
+    // update induction variable at the end of the loop body
+    rewriter.setInsertionPointToEnd(bodyEndBlock);
+    auto step = forOp.getStep();
+
+    auto castedStep = typeConverter->materializeTargetConversion(
+        rewriter, loc, typeConverter->convertType(step.getType()), step);
+    rewriter.create<wasm::TempLocalGetOp>(loc, castedInductionVariable);
+    rewriter.create<wasm::TempLocalGetOp>(loc, castedStep);
+    rewriter.create<wasm::AddOp>(loc, rewriter.getI32Type());
+    rewriter.create<wasm::TempLocalSetOp>(loc, castedInductionVariable);
+
+    rewriter.replaceOpWithNewOp<wasm::BranchOp>(terminator, condBlock);
+
+    // add terminator at the end of the termination block
+    rewriter.setInsertionPointToEnd(terminationBlock);
+    rewriter.create<wasm::LoopEndOp>(loc);
+
+    rewriter.eraseOp(forOp);
+
+    return success();
+  }
+};
+
+void populateScfToWasmPatterns(TypeConverter &typeConverter,
+                               RewritePatternSet &patterns) {
+  patterns.add<ForLowering>(typeConverter, patterns.getContext());
+}
+
+} // namespace mlir::wasm

--- a/lib/Wasm/WasmOps.cpp
+++ b/lib/Wasm/WasmOps.cpp
@@ -29,3 +29,7 @@ void mlir::wasm::TempLocalOp::build(OpBuilder &builder, OperationState &state,
   state.addTypes(localType);
   state.addAttribute("type", mlir::TypeAttr::get(inner));
 }
+
+void mlir::wasm::LoopOp::build(OpBuilder &builder, OperationState &state) {
+  state.addRegion();
+}

--- a/wasm-opt/wasm-opt.cpp
+++ b/wasm-opt/wasm-opt.cpp
@@ -21,8 +21,8 @@ int main(int argc, char **argv) {
   // TODO: Register wasm passes here.
 
   mlir::DialectRegistry registry;
-  registry.insert<mlir::wasm::WasmDialect,
-                  mlir::arith::ArithDialect, mlir::func::FuncDialect>();
+  registry.insert<mlir::wasm::WasmDialect, mlir::arith::ArithDialect,
+                  mlir::func::FuncDialect, mlir::scf::SCFDialect>();
   // Add the following to include *all* MLIR Core dialects, or selectively
   // include what you need like above. You only need to register dialects that
   // will be *parsed* by the tool, not the one generated


### PR DESCRIPTION
~~It is better to implement typeconverter before finishing this.~~  done

# TODO
- [ ] Handle IndexType properly (currently we are treating it as the same as I32Type)
- [ ] Support loop-carried variables
