### PR TITLE
Rename --llvm-opt-flags to --llvm-opt-level

### DIFF
--- a/benchmark/polybench/README.md
+++ b/benchmark/polybench/README.md
@@ -116,7 +116,7 @@ return value, `print_count`, and `print_hash`:
 ```sh
 ./validate_small_correctness.py --wami-only --filter floyd-warshall
 ./validate_small_correctness.py --keep-temp
-./validate_small_correctness.py --binaryen-opt-flags=-O2 --llvm-opt-flags=-O3
+./validate_small_correctness.py --binaryen-opt-flags=-O2 --llvm-opt-level=O3
 ```
 
 ### Requirements

--- a/benchmark/polybench/gencmds.py
+++ b/benchmark/polybench/gencmds.py
@@ -49,7 +49,7 @@ def cmd(
     warmup: int = 0,
     skip_build: bool = False,
 ) -> str:
-    llvm_opt_flags = f"-O{llvm_opt_level}"
+    llvm_opt_flags = f"O{llvm_opt_level}"
     binaryen_opt_flags = f"-O{binaryen_opt_level}"
     skip_build_flag = "--skip-build" if skip_build else ""
 
@@ -70,7 +70,7 @@ def cmd(
             f"--device={device}",
             f"benchmark/polybench/{size}/{file_name}",
             f"--compiler={compiler}",
-            f"--llvm-opt-flags={llvm_opt_flags}" if compiler == "llvm" else "",
+            f"--llvm-opt-level={llvm_opt_flags}" if compiler == "llvm" else "",
             f"--binaryen-opt-flags={binaryen_opt_flags}",
             f"--use-aot={'true' if use_aot else 'false'}",
             "--silent",
@@ -84,7 +84,7 @@ def cmd(
             f"--device={device}",
             f"benchmark/polybench/{size}/{file_name}",
             f"--compiler={compiler}",
-            f"--llvm-opt-flags={llvm_opt_flags}" if compiler == "llvm" else "",
+            f"--llvm-opt-level={llvm_opt_flags}" if compiler == "llvm" else "",
             f"--binaryen-opt-flags={binaryen_opt_flags}",
             f"--use-aot={'true' if use_aot else 'false'}",
             skip_build_flag,
@@ -96,7 +96,7 @@ def cmd(
             f"--device={device}",
             f"benchmark/polybench/{size}/{file_name}",
             f"--compiler={compiler}",
-            f"--llvm-opt-flags={llvm_opt_flags}" if compiler == "llvm" else "",
+            f"--llvm-opt-level={llvm_opt_flags}" if compiler == "llvm" else "",
             f"--binaryen-opt-flags={binaryen_opt_flags}",
             f"--use-aot={'true' if use_aot else 'false'}",
             f"--iterations={iterations}" if iterations != 1 else "",
@@ -109,7 +109,7 @@ def cmd(
             f"--device={device}",
             f"benchmark/polybench/{size}/{file_name}",
             f"--compiler={compiler}",
-            f"--llvm-opt-flags={llvm_opt_flags}" if compiler == "llvm" else "",
+            f"--llvm-opt-level={llvm_opt_flags}" if compiler == "llvm" else "",
             f"--binaryen-opt-flags={binaryen_opt_flags}",
             f"--iterations={iterations}" if iterations != 1 else "",
             f"--warmup={warmup}" if warmup != 0 else "",

--- a/benchmark/polybench/validate_small_correctness.py
+++ b/benchmark/polybench/validate_small_correctness.py
@@ -81,7 +81,7 @@ def compile_wasm(
     compiler: str,
     out_dir: Path,
     binaryen_opt_flags: str,
-    llvm_opt_flags: str,
+    llvm_opt_level: str,
 ) -> Path:
     output_base = out_dir / f"{mlir_path.stem}-{compiler}"
     cmd: List[str] = [
@@ -94,8 +94,8 @@ def compile_wasm(
     ]
     if binaryen_opt_flags:
         cmd.append(f"--binaryen-opt-flags={binaryen_opt_flags}")
-    if compiler == "llvm" and llvm_opt_flags:
-        cmd.append(f"--llvm-opt-flags={llvm_opt_flags}")
+    if compiler == "llvm" and llvm_opt_level:
+        cmd.append(f"--llvm-opt-level={llvm_opt_level}")
     run_cmd(cmd, ROOT_DIR)
 
     wasm_path = output_base.with_suffix(".wasm")
@@ -169,9 +169,9 @@ def parse_args() -> argparse.Namespace:
         help="Optional Binaryen optimization flags forwarded to compile.sh.",
     )
     parser.add_argument(
-        "--llvm-opt-flags",
+        "--llvm-opt-level",
         default="",
-        help="Optional LLVM optimization flags forwarded to compile.sh for --compiler=llvm.",
+        help="LLVM optimization level forwarded to compile.sh for --compiler=llvm (e.g. O3).",
     )
     parser.add_argument(
         "--wami-only",
@@ -228,7 +228,7 @@ def main() -> int:
                 "wami",
                 tmp_dir,
                 args.binaryen_opt_flags,
-                args.llvm_opt_flags,
+                args.llvm_opt_level,
             )
             wami_report = run_wasm(wami_wasm, args.print_hash_seed)
 
@@ -245,7 +245,7 @@ def main() -> int:
                     "llvm",
                     tmp_dir,
                     args.binaryen_opt_flags,
-                    args.llvm_opt_flags,
+                    args.llvm_opt_level,
                 )
                 llvm_report = run_wasm(llvm_wasm, args.print_hash_seed)
                 mismatches = compare_reports(wami_report, llvm_report)

--- a/toolchain/compile.sh
+++ b/toolchain/compile.sh
@@ -9,7 +9,7 @@ ADD_DEBUG_FUNCTIONS=false
 BINARYEN_OPT_FLAGS=""
 COMPILER=""
 CLEAN=false
-LLVM_OPT_FLAGS=""
+LLVM_OPT_LEVEL="O3"
 SKIP_BUILD=false
 
 # Function to display usage information
@@ -19,7 +19,7 @@ usage() {
     echo "  -o, --output     Output base name"
     echo "  --compiler       Compiler to use (wami or llvm)"
     echo "  --binaryen-opt-flags    Perform WebAssembly optimization (optional)"
-    echo "  --llvm-opt-flags        Perform LLVM optimization (optional, only supported in --compiler=llvm)"
+    echo "  --llvm-opt-level        LLVM optimization level (default: O3, only supported in --compiler=llvm)"
     echo "  --add-debug-functions   Add debug functions to the output (optional, only supported in --compiler=wami)"
     echo "  --clean                 Remove temporary files after completion"
     exit 1
@@ -44,8 +44,8 @@ while [[ "$#" -gt 0 ]]; do
             BINARYEN_OPT_FLAGS="${1#*=}"
             shift
             ;;
-        --llvm-opt-flags=*)
-            LLVM_OPT_FLAGS="${1#*=}"
+        --llvm-opt-level=*)
+            LLVM_OPT_LEVEL="${1#*=}"
             shift
             ;;
         --add-debug-functions)
@@ -267,10 +267,10 @@ elif [[ "$COMPILER" == "llvm" ]]; then
 
     OUTPUT_OPT_LL="${OUTPUT_BASE}-opt-2b.ll"
     echo "Running LLVM middle-end optimizations on $OUTPUT_LL..."
-    opt -O3 -S "$OUTPUT_LL" -o "$OUTPUT_OPT_LL"
+    opt -$LLVM_OPT_LEVEL -S "$OUTPUT_LL" -o "$OUTPUT_OPT_LL"
 
     echo "Lowering $OUTPUT_OPT_LL to object file (.o)..."
-    llc $LLVM_OPT_FLAGS -filetype=obj -mtriple=wasm32-wasi "$OUTPUT_OPT_LL" -o "$OUTPUT_OBJ"
+    llc -$LLVM_OPT_LEVEL -filetype=obj -mtriple=wasm32-wasi "$OUTPUT_OPT_LL" -o "$OUTPUT_OBJ"
 
     echo "Converting $OUTPUT_OBJ to WAT format..."
     wasm2wat "$OUTPUT_OBJ" -o "$OUTPUT_WAT"
@@ -311,7 +311,7 @@ elif [[ "$COMPILER" == "llvm" ]]; then
     echo "  - $OUTPUT_PREPROCESSED (Preprocessed MLIR after shared optimizations)"
     echo "  - $OUTPUT_LLVM_MLIR (LLVM dialect MLIR)"
     echo "  - $OUTPUT_LL (LLVM IR)"
-    echo "  - $OUTPUT_OPT_LL (LLVM IR after opt -O3)"
+    echo "  - $OUTPUT_OPT_LL (LLVM IR after opt -$LLVM_OPT_LEVEL)"
     echo "  - $OUTPUT_OBJ (Object file)"
     echo "  - $OUTPUT_WAT (WAT format)"
 fi

--- a/toolchain/run.sh
+++ b/toolchain/run.sh
@@ -14,7 +14,7 @@ fi
 MLIR_FILE=""
 COMPILER="wami"  # Default type is wami
 DEVICE="mcu"  # Default device is mcu
-LLVM_OPT_FLAGS=""
+LLVM_OPT_LEVEL="O3"
 BINARYEN_OPT_FLAGS=""
 USE_AOT=false  # Default is to use interpreter
 AOT_FLAGS=""
@@ -34,8 +34,8 @@ while [[ "$#" -gt 0 ]]; do
             COMPILER="${1#*=}"
             shift
             ;;
-        --llvm-opt-flags=*)
-            LLVM_OPT_FLAGS="${1#*=}"
+        --llvm-opt-level=*)
+            LLVM_OPT_LEVEL="${1#*=}"
             shift
             ;;
         --binaryen-opt-flags=*)
@@ -103,7 +103,7 @@ SKIP_BUILD_FLAG=""
 if [ "$SKIP_BUILD" = true ]; then
     SKIP_BUILD_FLAG="--skip-build"
 fi
-COMPILE_CMD="\"$SCRIPT_DIR/compile.sh\" -i $MLIR_FILE -o $TEMP_DIR/$BASENAME --compiler=$COMPILER --llvm-opt-flags=\"$LLVM_OPT_FLAGS\"  --binaryen-opt-flags=\"$BINARYEN_OPT_FLAGS\" $SKIP_BUILD_FLAG"
+COMPILE_CMD="\"$SCRIPT_DIR/compile.sh\" -i $MLIR_FILE -o $TEMP_DIR/$BASENAME --compiler=$COMPILER --llvm-opt-level=\"$LLVM_OPT_LEVEL\"  --binaryen-opt-flags=\"$BINARYEN_OPT_FLAGS\" $SKIP_BUILD_FLAG"
 
 echo "Compiling $COMPILER to Wasm with command: $COMPILE_CMD"
 eval "$COMPILE_CMD"


### PR DESCRIPTION
## Summary
- The LLVM optimization level was hardcoded to `-O3` in `compile.sh`'s `opt` invocation, while `--llvm-opt-flags` only controlled `llc`
- Renamed `--llvm-opt-flags` to `--llvm-opt-level` (default: `O3`) and applied it consistently to both `opt` and `llc`
- Updated `run.sh`, `gencmds.py`, `validate_small_correctness.py`, and `README.md` to match

## Test plan
- [ ] Run `./toolchain/compile.sh -i <file> -o out --compiler=llvm` (uses default O3)
- [ ] Run `./toolchain/compile.sh -i <file> -o out --compiler=llvm --llvm-opt-level=O0` (verify O0 is used for both `opt` and `llc`)
- [ ] Run `./validate_small_correctness.py --llvm-opt-level=O3`